### PR TITLE
Fix for Unused import

### DIFF
--- a/tools/migrate_presentation_strings.py
+++ b/tools/migrate_presentation_strings.py
@@ -5,7 +5,6 @@ Run from repo root. Review diff before committing.
 """
 from __future__ import annotations
 
-import re
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
Remove the unused `re` import from `tools/migrate_presentation_strings.py`.

Best fix without changing functionality:
- Edit the import section at the top of the file.
- Delete `import re` (line 8 in the snippet).
- Keep all other imports intact (`sys`, `Path`, and future annotations).

No additional methods, definitions, or behavior changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._